### PR TITLE
feat(ui): アラート表示機能の実装とRosProviderの改善

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,17 @@
 import { GamepadsProvider } from 'react-ts-gamepads'
-import RosProvider from './RosProvider'
+import RosProvider from './providers/RosProvider'
+import ToastProvider from './providers/ToastProvider'
 import NavBar from './components/NavBar'
 
 function App() {
   return (
-    <RosProvider url="ws://localhost:9090">
-      <GamepadsProvider>
-        <NavBar />
-      </GamepadsProvider>
-    </RosProvider>
+    <ToastProvider>
+      <RosProvider url="ws://localhost:9090">
+        <GamepadsProvider>
+          <NavBar />
+        </GamepadsProvider>
+      </RosProvider>
+    </ToastProvider>
   )
 }
 

--- a/src/components/RosConnectButton.tsx
+++ b/src/components/RosConnectButton.tsx
@@ -1,10 +1,11 @@
 import { useContext } from 'react'
-import { RosContext } from '../RosProvider'
+import { RosContext } from '../providers/RosProvider'
 
 const RosConnectButton = () => {
   const { connectionState, connect, disconnect } = useContext(RosContext)
 
-  let handleClick: () => void, label: string, tone: string
+  let handleClick: (() => void) | undefined
+  let label: string, tone: string
   switch (connectionState) {
     case 'disconnected':
       handleClick = connect
@@ -15,6 +16,16 @@ const RosConnectButton = () => {
       handleClick = disconnect
       label = 'Cancel'
       tone = 'text-warning'
+      break
+    case 'disconnecting':
+      handleClick = undefined
+      label = 'Disconnecting...'
+      tone = 'text-muted'
+      break
+    case 'cancel_connecting':
+      handleClick = undefined
+      label = 'Cancelling...'
+      tone = 'text-muted'
       break
     case 'connected':
       handleClick = disconnect

--- a/src/components/RosConnectionStatus.tsx
+++ b/src/components/RosConnectionStatus.tsx
@@ -1,15 +1,24 @@
 import { useContext } from 'react'
 import { FaCircle } from 'react-icons/fa'
-import { RosContext } from '../RosProvider'
+import { RosContext } from '../providers/RosProvider'
 
 const RosConnectionStatus = () => {
   const { connectionState } = useContext(RosContext)
+
+  const isLoading =
+    connectionState === 'connecting' ||
+    connectionState === 'disconnecting' ||
+    connectionState === 'cancel_connecting'
 
   let label: string, tone: string
   switch (connectionState) {
     case 'connected':
       label = 'Connected'
       tone = 'badge-success'
+      break
+    case 'disconnecting':
+      label = 'Disconnecting...'
+      tone = 'badge-warning'
       break
     case 'connecting':
       label = 'Connecting...'
@@ -19,6 +28,10 @@ const RosConnectionStatus = () => {
       label = 'Disconnected'
       tone = 'badge-error'
       break
+    case 'cancel_connecting':
+      label = 'Cancelling...'
+      tone = 'badge-warning'
+      break
   }
 
   return (
@@ -27,7 +40,7 @@ const RosConnectionStatus = () => {
       aria-live="polite"
       className={`badge badge-soft ${tone}`}
     >
-      {connectionState == 'connecting' ? (
+      {isLoading ? (
         <span className="loading loading-spinner loading-xs"></span>
       ) : (
         <FaCircle />

--- a/src/providers/ToastProvider.tsx
+++ b/src/providers/ToastProvider.tsx
@@ -1,0 +1,95 @@
+import {
+  createContext,
+  useState,
+  type PropsWithChildren,
+  type ReactElement,
+} from 'react'
+import { FaInfoCircle, FaCheck, FaExclamationTriangle } from 'react-icons/fa'
+import { FaXmark } from 'react-icons/fa6'
+
+type ToastType = 'info' | 'success' | 'warning' | 'error'
+
+export type Toast = {
+  id: string
+  message: string
+  type: ToastType
+  timestamp: string
+}
+
+type ToastContextValue = {
+  show: (message: string, type?: ToastType) => void
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null)
+
+const ToastProvider = ({ children }: PropsWithChildren) => {
+  const [toasts, setToasts] = useState<Toast[]>([])
+
+  const addToast = (message: string, type: ToastType = 'info') => {
+    const id = crypto.randomUUID()
+
+    const timestamp = new Date().toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    })
+
+    setToasts((prev) => [...prev, { id, message, type, timestamp }])
+  }
+
+  const removeToast = (id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id))
+  }
+
+  const icons: Record<ToastType, ReactElement> = {
+    info: <FaInfoCircle />,
+    success: <FaCheck />,
+    warning: <FaExclamationTriangle />,
+    error: <FaExclamationTriangle />,
+  }
+
+  // Tailwindは動的なクラス名に非対応なのでワークアラウンドとして関数化
+  const getAlertClass = (type: ToastType) => {
+    switch (type) {
+      case 'info':
+        return 'alert-info'
+      case 'success':
+        return 'alert-success'
+      case 'warning':
+        return 'alert-warning'
+      case 'error':
+        return 'alert-error'
+    }
+  }
+
+  return (
+    <ToastContext value={{ show: addToast }}>
+      {children}
+
+      <div className="fixed inset-0 pointer-events-none z-50 flex items-end justify-end">
+        <div className="toast pointer-events-auto">
+          {toasts.map((toast) => (
+            <div
+              key={toast.id}
+              role="alert"
+              className={`alert alert-outline ${getAlertClass(toast.type)}`}
+            >
+              <span className="text-base-content/50">{toast.timestamp}</span>
+              {icons[toast.type]}
+              <span>{toast.message}</span>
+              <button
+                className="btn btn-xs btn-ghost"
+                onClick={() => removeToast(toast.id)}
+              >
+                <FaXmark />
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+    </ToastContext>
+  )
+}
+
+export default ToastProvider
+export { ToastContext }


### PR DESCRIPTION
close #7 
close #19

プール実験の際にrosbridgeとの通信が切れていることに気付かない場面があったので早めに実装しておきました。

任意のコンポーネントから`toast.show()`を呼び出すことで簡単にアラートを表示できます

<img width="2724" height="1790" alt="CleanShot 2025-11-27 at 01 07 53@2x" src="https://github.com/user-attachments/assets/35dc2554-a475-4927-810f-c8453f86ae48" />
