### PR TITLE
feat(camera): CameraViewerの実装

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,36 @@ import { GamepadsProvider } from 'react-ts-gamepads'
 import RosProvider from './providers/RosProvider'
 import ToastProvider from './providers/ToastProvider'
 import NavBar from './components/NavBar'
+import CameraViewer from './components/CameraViewer'
 
 function App() {
   return (
     <ToastProvider>
       <RosProvider url="ws://localhost:9090">
         <GamepadsProvider>
-          <NavBar />
+          <div className="flex flex-col h-screen overflow-hidden">
+            <NavBar />
+            <div className="flex-1 min-h-0">
+              {/* <div className="flex flex-row w-full h-full">
+                <div className="flex-1 min-w-0 min-h-0"> */}
+              <CameraViewer
+                hostname="http://umiusi2.local:8080"
+                topicName="/pi_camera/image_raw"
+                width={1024}
+                height={768}
+              />
+              {/* </div>
+                <div className="flex-1 min-w-0 min-h-0">
+                  <CameraViewer
+                    hostname="http://umiusi2.local:8080"
+                    topicName="/usb_camera/image_raw"
+                    width={1024}
+                    height={768}
+                  />
+                </div>
+              </div> */}
+            </div>
+          </div>
         </GamepadsProvider>
       </RosProvider>
     </ToastProvider>

--- a/src/components/CameraViewer.tsx
+++ b/src/components/CameraViewer.tsx
@@ -1,0 +1,60 @@
+import { useContext, useEffect, useRef, useState } from 'react'
+import { ToastContext } from '../providers/ToastProvider'
+
+type Props = {
+  hostname: string
+  topicName: string
+  width: number
+  height: number
+}
+
+type CameraViewerState = 'loading' | 'error' | 'ready'
+
+const CameraViewer = ({ hostname, topicName, width, height }: Props) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const imgRef = useRef(new Image())
+
+  const [state, setState] = useState<CameraViewerState>('loading')
+  const toast = useContext(ToastContext)
+
+  const url = `${hostname}/stream?topic=${topicName}&type=mjpeg&width=${width}&height=${height}`
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+
+    const ctx = canvas.getContext('2d')
+    const img = imgRef.current
+
+    img.src = url
+
+    const render = () => {
+      setState('ready')
+      ctx?.drawImage(img, 0, 0, width, height)
+      requestAnimationFrame(render)
+    }
+
+    img.onload = render
+
+    img.onerror = (err) => {
+      if (state !== 'error') {
+        console.error('Failed to load image stream:', err)
+        toast?.show('Failed to load image stream from ' + topicName, 'error')
+      }
+      setState('error')
+    }
+  }, [url, width, height, toast, topicName, state])
+
+  return (
+    <div className="w-full h-full bg-black flex items-center justify-center overflow-hidden">
+      <canvas
+        ref={canvasRef}
+        width={width}
+        height={height}
+        className="max-w-full max-h-full object-contain bg-black"
+      />
+    </div>
+  )
+}
+
+export default CameraViewer

--- a/src/providers/ToastProvider.tsx
+++ b/src/providers/ToastProvider.tsx
@@ -73,7 +73,7 @@ const ToastProvider = ({ children }: PropsWithChildren) => {
             <div
               key={toast.id}
               role="alert"
-              className={`alert alert-outline ${getAlertClass(toast.type)}`}
+              className={`alert alert-soft ${getAlertClass(toast.type)}`}
             >
               <span className="text-base-content/50">{toast.timestamp}</span>
               {icons[toast.type]}


### PR DESCRIPTION
`ros_web_server`がエクスポートしているmjpegのストリームを見れるようにしました。

本来はUSBカメラの映像と横並びに表示できるようになっていますが、USBカメラが不調のためコメントアウトしてあります。

<img width="3132" height="1872" alt="CleanShot 2025-11-27 at 17 06 43@2x" src="https://github.com/user-attachments/assets/19e6f278-c088-4372-a1af-6362bb9dcbbd" />
